### PR TITLE
Google maps marker Custom images and Info Window

### DIFF
--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -568,6 +568,7 @@ function prepareGoogleMaps() {
                                 lat: marker.lat,
                                 lng: marker.lng,
                                 icon: marker.iconUrl,
+                                animation: marker.animation,
                             } );
                             if ( marker.infoWindow ) {
                                 const infowindow = new window.google.maps.InfoWindow( {

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -567,12 +567,16 @@ function prepareGoogleMaps() {
                             const mapMarker = mapObject.addMarker( {
                                 lat: marker.lat,
                                 lng: marker.lng,
-                                icon: marker.iconUrl,
+                                icon: {
+                                    url: marker.iconUrl, // url
+                                    scaledSize: new window.google.maps.Size( 30, 30 ), // scaled size
+                                },
                                 animation: marker.animation,
                             } );
                             if ( marker.infoWindow ) {
                                 const infowindow = new window.google.maps.InfoWindow( {
                                     content: marker.infoWindow,
+                                    maxWidth: 150,
                                 } );
                                 mapMarker.addListener( 'click', function() {
                                     infowindow.open( mapObject, mapMarker );

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -564,10 +564,19 @@ function prepareGoogleMaps() {
 
                     if ( markers && markers.length ) {
                         markers.forEach( ( marker ) => {
-                            mapObject.addMarker( {
+                            const mapMarker = mapObject.addMarker( {
                                 lat: marker.lat,
                                 lng: marker.lng,
+                                icon: marker.iconUrl,
                             } );
+                            if ( marker.infoWindow ) {
+                                const infowindow = new window.google.maps.InfoWindow( {
+                                    content: marker.infoWindow,
+                                } );
+                                mapMarker.addListener( 'click', function() {
+                                    infowindow.open( mapObject, mapMarker );
+                                } );
+                            }
                         } );
                     }
                 } );

--- a/src/blocks/google-maps/editor.scss
+++ b/src/blocks/google-maps/editor.scss
@@ -66,6 +66,7 @@
 
 // markers
 .ghostkit-google-maps-markers {
+
     li {
         margin-bottom: 15px;
 
@@ -76,6 +77,12 @@
             margin-right: -16px;
             margin-left: -16px;
             border-bottom: 1px solid #efefef;
+        }
+
+        .marker-image-preview {
+            float: right;
+            max-width: 55px;
+            max-height: 55px;
         }
     }
 

--- a/src/blocks/google-maps/editor.scss
+++ b/src/blocks/google-maps/editor.scss
@@ -84,6 +84,11 @@
             max-width: 55px;
             max-height: 55px;
         }
+
+        .marker-icon-picker-container{
+            height: 45px;
+            margin: 20px 0;
+        }
     }
 
     .ghostkit-google-maps-marker-remove {

--- a/src/blocks/google-maps/index.jsx
+++ b/src/blocks/google-maps/index.jsx
@@ -274,7 +274,9 @@ class GoogleMapsBlock extends Component {
                                                     } }
                                                     render={ function( obj ) {
                                                         return (
-                                                            <Fragment>
+                                                            <div
+                                                                className="marker-icon-picker-container"
+                                                            >
                                                                 <Button
                                                                     className="components-icon-button components-toolbar__control"
                                                                     onClick={ obj.open }
@@ -288,7 +290,7 @@ class GoogleMapsBlock extends Component {
                                                                     </SVG>
                                                                 </Button>
                                                                 { marker.iconUrl ? <img alt={ __( 'Google Map Custom' ) } src={ marker.iconUrl } className="marker-image-preview" /> : <img alt={ __( 'Google Map Marker Default' ) } src="https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2.png" className="marker-image-preview" /> }
-                                                            </Fragment>
+                                                            </div>
                                                         );
                                                     } }
                                                 />
@@ -302,6 +304,22 @@ class GoogleMapsBlock extends Component {
                                                         // from where if html given in html attribute it will not properly be fetched back
                                                         // and converted to JSON again.
                                                         markers[ index ].infoWindow = text.replace( /<[^>]*>/g, '' );
+                                                        return setAttributes( {
+                                                            markers: Object.assign( [], markers ),
+                                                        } );
+                                                    } }
+                                                />
+                                                <SelectControl
+                                                    label={ __( 'Marker Animations' ) }
+                                                    value={ markers[ index ].animation }
+                                                    options={ [
+                                                        { label: 'None', value: 0 },
+                                                        { label: 'BOUNCE', value: 1 },
+                                                        { label: 'DROP', value: 2 },
+                                                        { label: 'DROP SHORT', value: 4 },
+                                                    ] }
+                                                    onChange={ ( animation ) => {
+                                                        markers[ index ].animation = animation;
                                                         return setAttributes( {
                                                             markers: Object.assign( [], markers ),
                                                         } );

--- a/src/blocks/google-maps/index.jsx
+++ b/src/blocks/google-maps/index.jsx
@@ -31,11 +31,14 @@ const {
     ToggleControl,
     Button,
     Toolbar,
+    SVG,
+    Path,
 } = wp.components;
 
 const {
     InspectorControls,
     BlockControls,
+    MediaUpload,
 } = wp.editor;
 
 const { apiFetch } = wp;
@@ -258,6 +261,51 @@ class GoogleMapsBlock extends Component {
                                                         }
                                                     } }
                                                     className="ghostkit-google-maps-search-box"
+                                                />
+                                                <MediaUpload
+                                                    allowedTypes={ [ 'image' ] }
+                                                    value={ marker.iconId }
+                                                    onSelect={ function( media ) {
+                                                        markers[ index ].iconId = media.id;
+                                                        markers[ index ].iconUrl = media.url;
+                                                        return setAttributes( {
+                                                            markers: Object.assign( [], markers ),
+                                                        } );
+                                                    } }
+                                                    render={ function( obj ) {
+                                                        return (
+                                                            <Fragment>
+                                                                <Button
+                                                                    className="components-icon-button components-toolbar__control"
+                                                                    onClick={ obj.open }
+                                                                >
+                                                                    <SVG
+                                                                        className="dashicon dashicons-edit"
+                                                                        width="20"
+                                                                        height="20"
+                                                                    >
+                                                                        <Path d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z" />
+                                                                    </SVG>
+                                                                </Button>
+                                                                { marker.iconUrl ? <img alt={ __( 'Google Map Custom' ) } src={ marker.iconUrl } className="marker-image-preview" /> : <img alt={ __( 'Google Map Marker Default' ) } src="https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2.png" className="marker-image-preview" /> }
+                                                            </Fragment>
+                                                        );
+                                                    } }
+                                                />
+                                                <TextareaControl
+                                                    label={ __( 'Info Window Text' ) }
+                                                    help={ __( 'Optional' ) }
+                                                    value={ markers[ index ].infoWindow }
+                                                    onChange={ function( text ) {
+                                                        // no HTML inside markers right now possible because
+                                                        // we are doing stringify of json in a data attribute for frontend
+                                                        // from where if html given in html attribute it will not properly be fetched back
+                                                        // and converted to JSON again.
+                                                        markers[ index ].infoWindow = text.replace( /<[^>]*>/g, '' );
+                                                        return setAttributes( {
+                                                            markers: Object.assign( [], markers ),
+                                                        } );
+                                                    } }
                                                 />
                                                 <Button
                                                     onClick={ () => {

--- a/src/blocks/google-maps/index.jsx
+++ b/src/blocks/google-maps/index.jsx
@@ -245,8 +245,7 @@ class GoogleMapsBlock extends Component {
                                             <li key={ index }>
                                                 <SearchBox
                                                     googleMapURL={ mapsUrl + '&key=' + this.state.apiKey }
-                                                    placeholder={ __( 'Enter address' ) }
-                                                    value={ marker.address || this.state.addresses[ marker.lat + marker.lng ] || '' }
+                                                    placeholder={ marker.address || this.state.addresses[ marker.lat + marker.lng ] || '' }
                                                     onChange={ ( value ) => {
                                                         if ( value && value[ 0 ] ) {
                                                             markers[ index ].address = value[ 0 ].formatted_address;

--- a/src/blocks/google-maps/map-block.jsx
+++ b/src/blocks/google-maps/map-block.jsx
@@ -61,6 +61,7 @@ const MapBlock = compose(
                     key={ index }
                     position={ { lat: marker.lat, lng: marker.lng } }
                     icon={ marker.iconUrl }
+                    animation={ marker.animation ? marker.animation : '' }
                     onClick={ () => props.showInfo( index ) }
                 >
                     { ( props.isOpen && marker.infoWindow && props.infoIndex === index ) &&

--- a/src/blocks/google-maps/map-block.jsx
+++ b/src/blocks/google-maps/map-block.jsx
@@ -1,12 +1,24 @@
-import { compose, withProps, withHandlers } from 'recompose';
+import { compose, withProps, withHandlers, withStateHandlers } from 'recompose';
 import {
     withScriptjs,
     withGoogleMap,
     GoogleMap,
     Marker,
+    InfoWindow,
 } from 'react-google-maps';
 
 const MapBlock = compose(
+    withStateHandlers( () => ( {
+        isOpen: false,
+    } ), {
+        onToggleOpen: ( { isOpen } ) => () => ( {
+            isOpen: ! isOpen,
+        } ),
+        showInfo: ( { isOpen, infoIndex } ) => ( index ) => ( {
+            isOpen: infoIndex !== index || ! isOpen,
+            infoIndex: index,
+        } ),
+    } ),
     withProps( {
         loadingElement: <div style={ { height: '100%' } } />,
         mapElement: <div style={ { height: '100%' } } />,
@@ -48,7 +60,15 @@ const MapBlock = compose(
                 <Marker
                     key={ index }
                     position={ { lat: marker.lat, lng: marker.lng } }
-                />
+                    icon={ marker.iconUrl }
+                    onClick={ () => props.showInfo( index ) }
+                >
+                    { ( props.isOpen && marker.infoWindow && props.infoIndex === index ) &&
+                    <InfoWindow onCloseClick={ props.onToggleOpen }>
+                        <div dangerouslySetInnerHTML={ { __html: marker.infoWindow } }>
+                        </div>
+                    </InfoWindow> }
+                </Marker>
             ) ) }
         </GoogleMap>
     );

--- a/src/blocks/google-maps/map-block.jsx
+++ b/src/blocks/google-maps/map-block.jsx
@@ -60,12 +60,18 @@ const MapBlock = compose(
                 <Marker
                     key={ index }
                     position={ { lat: marker.lat, lng: marker.lng } }
-                    icon={ marker.iconUrl }
+                    icon={ {
+                        url: marker.iconUrl, // url
+                        scaledSize: new window.google.maps.Size( 30, 30 ), // scaled size
+                    } }
                     animation={ marker.animation ? marker.animation : '' }
                     onClick={ () => props.showInfo( index ) }
                 >
                     { ( props.isOpen && marker.infoWindow && props.infoIndex === index ) &&
-                    <InfoWindow onCloseClick={ props.onToggleOpen }>
+                    <InfoWindow
+                        onCloseClick={ props.onToggleOpen }
+                        options={ { maxWidth: '150' } }
+                    >
                         <div dangerouslySetInnerHTML={ { __html: marker.infoWindow } }>
                         </div>
                     </InfoWindow> }


### PR DESCRIPTION
Right now because you are using data-* attribute to send markers to the frontend and then converting them back to JSON. so because of HTML inside one HTML attribute, things are not working fine if HTML added to the info window. so, for now, I am removing any HTML added to the info window automatically.