### PR TITLE
Column class duplication

### DIFF
--- a/src/blocks/grid/column.jsx
+++ b/src/blocks/grid/column.jsx
@@ -106,11 +106,13 @@ const getColClass = ( attributes ) => {
             if ( type && ( type === 'size' || type === 'order' ) ) {
                 prefix = prefix ? `-${ prefix }` : '';
                 type = type === 'size' ? '' : `-${ type }`;
-
-                result = classnames(
-                    result,
-                    `ghostkit-col${ type }${ prefix || '' }${ attributes[ key ] !== 'auto' ? `-${ attributes[ key ] }` : '' }`
-                );
+                
+                if ( result.indexOf( `gg-col${ type }${ prefix }` ) < 0 ) {
+                    result = classnames(
+                        result,
+                        `ghostkit-col${ type }${ prefix || '' }${ attributes[ key ] !== 'auto' ? `-${ attributes[ key ] }` : '' }`
+                    );
+                }
             }
         }
     } );


### PR DESCRIPTION
Avoid re-adding the same class name if the class name with the same type and prefix exist.

Problem: Add grid block, click save, add paragraph block to the grid, click save. Now preview the frontend, you will see duplication of classes with 'ghostkit-col-md-12 ghostkit-col-6 ghostkit-col-md-12 ghostkit-col-6' appearing twice.